### PR TITLE
Reject portfolio names containing storage delimiter |

### DIFF
--- a/src/main/java/duke/PortfolioBook.java
+++ b/src/main/java/duke/PortfolioBook.java
@@ -79,7 +79,11 @@ public class PortfolioBook {
         if (name == null || name.isBlank()) {
             throw new AppException("Portfolio name cannot be blank");
         }
-        return name.trim();
+        String trimmed = name.trim();
+        if (trimmed.contains("|")) {
+            throw new AppException("Portfolio name cannot contain '|'");
+        }
+        return trimmed;
     }
 
     private String requirePortfolioKey(String name) throws AppException {

--- a/src/test/java/duke/PortfolioBookTest.java
+++ b/src/test/java/duke/PortfolioBookTest.java
@@ -39,6 +39,15 @@ public class PortfolioBookTest {
     }
 
     @Test
+    void createPortfolio_nameContainingDelimiter_throws() {
+        PortfolioBook book = new PortfolioBook();
+
+        AppException ex = assertThrows(AppException.class, () -> book.createPortfolio("my|portfolio"));
+
+        assertEquals("Portfolio name cannot contain '|'", ex.getMessage());
+    }
+
+    @Test
     void usePortfolio_acceptsMixedCaseName() throws AppException {
         PortfolioBook book = new PortfolioBook();
         book.createPortfolio("first");


### PR DESCRIPTION
Add validation in PortfolioBook#createPortfolio(...) to reject portfolio names containing | Prevent storage corruption from names like my|portfolio that would break the PORTFOLIO|... line format Add regression test in PortfolioBookTest for the new validation message