### PR TITLE
Fix /insights incorrectly labels "Top detractor"

### DIFF
--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -414,9 +414,11 @@ public class Ui {
             System.out.println("- Top contributor: " + bestHolding.getTicker()
                     + " " + formatSignedMoney(bestHolding.getUnrealizedPnl()));
         }
-        if (worstHolding != null) {
+        if (worstHolding != null && worstHolding.getUnrealizedPnl() < 0) {
             System.out.println("- Top detractor: " + worstHolding.getTicker()
                     + " " + formatSignedMoney(worstHolding.getUnrealizedPnl()));
+        } else {
+            System.out.println("- Top detractor: none");
         }
     }
 

--- a/src/test/java/duke/UiTest.java
+++ b/src/test/java/duke/UiTest.java
@@ -227,6 +227,24 @@ public class UiTest {
     }
 
     @Test
+    void showInsightsTable_allPositiveHoldings_showsNoTopDetractor() {
+        Ui ui = new Ui();
+        Portfolio portfolio = new Portfolio("t1");
+        portfolio.addHolding(AssetType.STOCK, "AAA", 1, 100, 0);
+        portfolio.addHolding(AssetType.STOCK, "BBB", 1, 100, 0);
+
+        portfolio.setPriceForHolding(AssetType.STOCK, "AAA", 110);
+        portfolio.setPriceForHolding(AssetType.STOCK, "BBB", 105);
+
+        ui.showInsightsTable(portfolio, null, null, false);
+
+        String output = capturedOut.toString();
+        assertTrue(output.contains("- Holdings: 2 (priced: 2, unpriced: 0)"));
+        assertTrue(output.contains("- Top contributor: AAA +10.00"));
+        assertTrue(output.contains("- Top detractor: none"));
+    }
+
+    @Test
     void formatHelpers_roundAsExpected() {
         assertEquals("123.46", Ui.formatMoney(123.456));
         assertEquals("12.34", Ui.formatNumber(12.340000));


### PR DESCRIPTION
Update Ui.showInsightsTable(...) so - Top detractor: none is shown when the worst priced holding has zero or positive unrealized P&L Prevent the command from incorrectly labeling the lowest positive contributor as a detractor Add regression coverage in UiTest for all-positive holdings in /insights