### PR TITLE
Added Assertions

### DIFF
--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -43,24 +43,33 @@ public class Parser {
     }
 
     private ParsedCommand parseCreate(List<String> tokens) throws AppException {
+        assert tokens != null && !tokens.isEmpty() : "tokens must not be null or empty";
         if (tokens.size() < 2) {
             throw new AppException("Usage: /create NAME");
         }
-        String name = joinTail(tokens, 1);
-        if (name.stripLeading().startsWith("/")) {
-            throw new AppException("Portfolio name cannot start with '/'");
-        }
-        return new ParsedCommand(CommandType.CREATE, name, null, null, null, null,
+        String name = joinTail(tokens, 1).strip();
+        assert name != null : "portfolio name must not be null after joining";
+        validatePortfolioName(name);
+        ParsedCommand result = new ParsedCommand(CommandType.CREATE, name, null, null, null, null,
                 null, null, null, null, null);
+        assert result.type() == CommandType.CREATE : "Command type must be CREATE";
+        assert result.name().equals(name) : "Command name must match provided name";
+        return result;
     }
 
     private ParsedCommand parseUse(List<String> tokens) throws AppException {
+        assert tokens != null && !tokens.isEmpty() : "tokens must not be null or empty";
         if (tokens.size() < 2) {
             throw new AppException("Usage: /use NAME");
         }
-        String name = joinTail(tokens, 1);
-        return new ParsedCommand(CommandType.USE, name, null, null, null, null,
+        String name = joinTail(tokens, 1).strip();
+        assert name != null : "portfolio name must not be null after joining";
+        validatePortfolioName(name);
+        ParsedCommand result = new ParsedCommand(CommandType.USE, name, null, null, null, null,
                 null, null, null, null, null);
+        assert result.type() == CommandType.USE : "Command type must be USE";
+        assert result.name().equals(name) : "Command name must match provided name";
+        return result;
     }
 
     private ParsedCommand parseList(List<String> tokens) throws AppException {
@@ -309,6 +318,15 @@ public class Parser {
         }
     }
 
+    private void validatePortfolioName(String name) throws AppException {
+        if (name == null || name.isBlank()) {
+            throw new AppException("Portfolio name must not be blank");
+        }
+        if (name.startsWith("/")) {
+            throw new AppException("Portfolio name cannot start with '/'");
+        }
+    }
+
     private String normaliseTicker(String rawTicker) {
         return rawTicker.toUpperCase();
     }
@@ -318,6 +336,7 @@ public class Parser {
     }
 
     private List<String> tokenise(String input) throws AppException {
+        assert input != null : "input must not be null";
         List<String> tokens = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean inQuotes = false;
@@ -349,6 +368,7 @@ public class Parser {
             tokens.add(current.toString());
         }
 
+        assert tokens != null : "tokenise result cannot be null";
         return tokens;
     }
 }

--- a/src/main/java/duke/Portfolio.java
+++ b/src/main/java/duke/Portfolio.java
@@ -27,19 +27,28 @@ public class Portfolio {
     }
 
     public double addHolding(AssetType assetType, String ticker, double quantity, double purchasePrice, double fees) {
+        assert assetType != null : "assetType must not be null";
+        assert ticker != null && !ticker.isBlank() : "ticker must not be null or blank";
+        assert quantity > 0 && purchasePrice > 0 : "quantity and purchasePrice must be positive";
+
         String key = makeKey(assetType, ticker);
 
         if (holdings.containsKey(key)) {
             Holding existing = holdings.get(key);
             existing.addQuantity(quantity, purchasePrice, fees);
             existing.setLastPrice(purchasePrice);
-            return existing.getQuantity();
+            double resultQty = existing.getQuantity();
+            assert resultQty > 0 : "Updated holding quantity must be positive";
+            return resultQty;
         }
 
         double effectivePurchasePrice = ((purchasePrice * quantity) + fees) / quantity;
         Holding holding = new Holding(assetType, ticker, quantity, effectivePurchasePrice);
         holdings.put(key, holding);
-        return holding.getQuantity();
+        assert holdings.containsKey(key) : "Holding was not added to portfolio";
+        double resultQty = holding.getQuantity();
+        assert resultQty == quantity : "Added holding quantity should match requested quantity";
+        return resultQty;
     }
 
     public Holding getHolding(AssetType assetType, String ticker) {
@@ -133,7 +142,12 @@ public class Portfolio {
     }
 
     public List<Holding> getHoldings() {
-        return new ArrayList<>(holdings.values());
+        List<Holding> result = new ArrayList<>(holdings.values());
+        assert result != null : "getHoldings result cannot be null";
+        for (Holding h : result) {
+            assert h != null : "Holdings list should not contain null entries";
+        }
+        return result;
     }
 
     public double getTotalRealizedPnl() {

--- a/src/main/java/duke/PortfolioBook.java
+++ b/src/main/java/duke/PortfolioBook.java
@@ -18,15 +18,18 @@ public class PortfolioBook {
 
     public void createPortfolio(String name) throws AppException {
         String displayName = requireDisplayPortfolioName(name);
+        assert displayName != null && !displayName.isBlank() : "displayName must not be null or blank";
         String portfolioKey = toPortfolioKey(displayName);
         if (portfolios.containsKey(portfolioKey)) {
             throw new AppException("Portfolio already exists: " + portfolios.get(portfolioKey).getName());
         }
 
         portfolios.put(portfolioKey, new Portfolio(displayName));
+        assert portfolios.containsKey(portfolioKey) : "Created portfolio must be in the book";
 
         if (activePortfolioKey == null) {
             activePortfolioKey = portfolioKey;
+            assert activePortfolioKey != null : "Active portfolio key must be set on first creation";
         }
     }
 
@@ -39,11 +42,13 @@ public class PortfolioBook {
 
     public void usePortfolio(String name) throws AppException {
         String displayName = requireDisplayPortfolioName(name);
+        assert displayName != null && !displayName.isBlank() : "displayName must not be null or blank";
         String portfolioKey = toPortfolioKey(displayName);
         if (!portfolios.containsKey(portfolioKey)) {
             throw new AppException("Portfolio not found: " + displayName);
         }
         activePortfolioKey = portfolioKey;
+        assert activePortfolioKey.equals(portfolioKey) : "Active portfolio key was not updated";
     }
 
     public boolean hasActivePortfolio() {
@@ -66,7 +71,12 @@ public class PortfolioBook {
     }
 
     public List<Portfolio> getPortfolios() {
-        return new ArrayList<>(portfolios.values());
+        List<Portfolio> result = new ArrayList<>(portfolios.values());
+        assert result != null : "getPortfolios result cannot be null";
+        for (Portfolio p : result) {
+            assert p != null : "Portfolios list should not contain null entries";
+        }
+        return result;
     }
 
     public Portfolio getPortfolio(String name) {

--- a/src/main/java/duke/Storage.java
+++ b/src/main/java/duke/Storage.java
@@ -31,6 +31,7 @@ public class Storage {
     }
 
     public PortfolioBook load() throws AppException {
+        assert filePath != null : "Storage file path must not be null";
         createStorageFileIfMissing();
         assert Files.exists(filePath) : "Storage file should exist after initialization";
 
@@ -74,6 +75,7 @@ public class Storage {
                 applyActivePortfolio(portfolioBook, activePortfolioName);
             }
 
+            assert portfolioBook != null : "Loaded portfolio book cannot be null";
             return portfolioBook;
         } catch (IllegalArgumentException e) {
             throw new AppException(CORRUPTED_FILE_MESSAGE);
@@ -105,10 +107,12 @@ public class Storage {
     }
 
     public void save(PortfolioBook portfolioBook) throws AppException {
+        assert portfolioBook != null : "portfolioBook must not be null";
         if (portfolioBook == null) {
             throw new IllegalArgumentException("portfolioBook must not be null");
         }
         createStorageFileIfMissing();
+        assert Files.exists(filePath) : "Storage file should exist after creation";
 
         List<String> lines = new ArrayList<>();
         lines.add("ACTIVE|" + nullToEmpty(portfolioBook.getActivePortfolioName()));
@@ -133,6 +137,8 @@ public class Storage {
 
         try {
             Files.write(filePath, lines);
+            assert Files.exists(filePath) : "Storage file must exist after write";
+            assert Files.size(filePath) > 0 : "Storage file should contain data after write";
         } catch (IOException e) {
             throw new AppException("Unable to save storage file.");
         }

--- a/src/test/java/duke/ParserTest.java
+++ b/src/test/java/duke/ParserTest.java
@@ -202,6 +202,18 @@ public class ParserTest {
     }
 
     @Test
+    void parseCreate_withBlankQuotedName_throws() {
+        AppException ex = assertThrows(AppException.class, () -> parser.parse("/create \" \""));
+        assertEquals("Portfolio name must not be blank", ex.getMessage());
+    }
+
+    @Test
+    void parseUse_withBlankQuotedName_throws() {
+        AppException ex = assertThrows(AppException.class, () -> parser.parse("/use \" \""));
+        assertEquals("Portfolio name must not be blank", ex.getMessage());
+    }
+
+    @Test
     void parseCreate_withUnclosedQuote_throws() {
         assertThrows(AppException.class, () -> parser.parse("/create \"long term portfolio"));
     }


### PR DESCRIPTION
Fix blank portfolio name validation and add state invariant assertions
- Reject portfolio names that are blank after trimming in Parser
  - validatePortfolioName() centralizes checks for blank/null/slash-prefixed names
  - Applies .strip() to remove leading/trailing whitespace before validation
  - Covers /create and /use commands
- Add regression tests for blank quoted portfolio names -parseCreate_withBlankQuotedName_throws()
  - parseUse_withBlankQuotedName_throws()

- Add defensive assertions for method contracts
  - Portfolio: precondition/postcondition checks in addHolding(), null-entry checks in getHoldings()
  - PortfolioBook: state transition verification in createPortfolio() and usePortfolio(), collection integrity in getPortfolios()
  - Storage: file existence and data integrity checks in load() and save()
  - Parser: input validation and output postcondition checks in parseCreate(), parseUse(), tokenise()